### PR TITLE
CI: Split the Build Jobs for Arm64 and x86_64

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -42,10 +42,15 @@ jobs:
             exit
           fi
 
+          # Ignore the Label "Area: Documentation", because it won't affect the Build Targets
+          query='.labels | map(select(.name != "Area: Documentation")) | '
+          select_name='.[].name'
+          select_length='length'
+
           # Get the Labels for the PR: "Arch: risc-v \n Board: risc-v \n Size: XS"
           # If GitHub CLI Fails: Build all targets
-          labels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.labels[] | .name' || echo "")
-          numlabels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq '.[] | length' || echo "")
+          labels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq $query$select_name || echo "")
+          numlabels=$(gh pr view $pr --repo $GITHUB_REPOSITORY --json labels --jq $query$select_length || echo "")
           echo "numlabels=$numlabels" | tee -a $GITHUB_OUTPUT
 
           # Identify the Size, Arch and Board Labels

--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -171,37 +171,37 @@ jobs:
             
             # For "Arch / Board: arm": Build arm-01, arm-02, ...
             if [[ "$arch_contains_arm" == "1" || "$board_contains_arm" == "1" ]]; then
-              if [[ "$board" != *"arm"* ]]; then
+              if [[ "$board" != *"arm-"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch / Board: arm64": Build other
+            # For "Arch / Board: arm64": Build arm64-01
             elif [[ "$arch_contains_arm64" == "1" || "$board_contains_arm64" == "1" ]]; then
-              if [[ "$board" != *"other"* ]]; then
+              if [[ "$board" != *"arm64-"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch / Board: risc-v": Build risc-v-01, risc-v-02
+            # For "Arch / Board: risc-v": Build risc-v-01, risc-v-02, ...
             elif [[ "$arch_contains_riscv" == "1" || "$board_contains_riscv" == "1" ]]; then
-              if [[ "$board" != *"risc-v"* ]]; then
+              if [[ "$board" != *"risc-v-"* ]]; then
                 skip_build=1
               fi
   
             # For "Arch / Board: simulator": Build sim-01, sim-02
             elif [[ "$arch_contains_sim" == "1" || "$board_contains_sim" == "1" ]]; then
-              if [[ "$board" != *"sim"* ]]; then
+              if [[ "$board" != *"sim-"* ]]; then
                 skip_build=1
               fi
 
-            # For "Arch / Board: x86_64": Build other
+            # For "Arch / Board: x86_64": Build x86_64-01
             elif [[ "$arch_contains_x86_64" == "1" || "$board_contains_x86_64" == "1" ]]; then
-              if [[ "$board" != *"other"* ]]; then
+              if [[ "$board" != *"x86_64-"* ]]; then
                 skip_build=1
               fi
   
             # For "Arch / Board: xtensa": Build xtensa-01, xtensa-02
             elif [[ "$arch_contains_xtensa" == "1" || "$board_contains_xtensa" == "1" ]]; then
-              if [[ "$board" != *"xtensa"* ]]; then
+              if [[ "$board" != *"xtensa-"* ]]; then
                 skip_build=1
               fi
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
+          #### repository: apache/nuttx
+          repository: lupyuen5/label-nuttx ####
           ref: ${{ steps.gittargets.outputs.os_ref }}
           path: sources/nuttx
           fetch-depth: 1
@@ -125,7 +126,7 @@ jobs:
       os: Linux
       boards: |
         [
-          "arm-01", "other", "risc-v-01", "sim-01", "xtensa-01",
+          "arm-01", "risc-v-01", "sim-01", "xtensa-01", "arm64-01", "x86_64-01", "other",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
           "arm-03", "risc-v-03",
           "arm-04", "risc-v-04",

--- a/tools/ci/testlist/arm64-01.dat
+++ b/tools/ci/testlist/arm64-01.dat
@@ -1,0 +1,11 @@
+/arm64
+
+# arm64 Boards build by CMake
+CMake,qemu-armv8a:citest
+CMake,qemu-armv8a:citest_smp
+CMake,qemu-armv8a:nsh
+CMake,qemu-armv8a:nsh_fiq
+CMake,qemu-armv8a:nsh_gicv2
+CMake,qemu-armv8a:nsh_smp
+CMake,qemu-armv8a:nsh_smp_tickless
+CMake,qemu-armv8a:sotest

--- a/tools/ci/testlist/other.dat
+++ b/tools/ci/testlist/other.dat
@@ -11,22 +11,6 @@
 
 /x86
 
-# x86_64-elf-gcc from homebrew doesn't seem to
-# provide __udivdi3 etc for -m32
-/x86_64
-
 # Sparc-gaisler-elf toolchain doesn't provide macOS binaries
 /sparc
 -xx3823:nsh
-
-/arm64
-
-# arm64 Boards build by CMake
-CMake,qemu-armv8a:citest
-CMake,qemu-armv8a:citest_smp
-CMake,qemu-armv8a:nsh
-CMake,qemu-armv8a:nsh_fiq
-CMake,qemu-armv8a:nsh_gicv2
-CMake,qemu-armv8a:nsh_smp
-CMake,qemu-armv8a:nsh_smp_tickless
-CMake,qemu-armv8a:sotest

--- a/tools/ci/testlist/x86_64-01.dat
+++ b/tools/ci/testlist/x86_64-01.dat
@@ -1,0 +1,3 @@
+# x86_64-elf-gcc from homebrew doesn't seem to
+# provide __udivdi3 etc for -m32
+/x86_64


### PR DESCRIPTION
## Summary

This PR creates the new CI Build Jobs `arm64-01` and `x86_64-01`. The new jobs will split and offload the Arm64 and x86_64 Build Targets from `other`. This will reduce our usage of GitHub Runners, to comply with the ASF Policy for GitHub Actions. (Recently we see more PRs for Arm64 and x86_64)

__Before the PR:__ Simple PRs (One Arch and/or One Board) for Arm64 and x86_64 require almost 1 hour for CI Build
- `other` (56 mins): AVR, SPARC, x86, PinePhone, QEMU Arm64, QEMU x86_64

__After the PR:__ Simple PRs for Arm64 and x86_64 will complete within ??? mins
- `other` (??? mins): AVR, SPARC, x86
- `arm64-01` (??? mins): PinePhone, QEMU Arm64
- `x86_64-01` (??? mins): QEMU x86_64

To skip more unnecessary builds: Our Build Rules `arch.yml` shall ignore the label "Area: Documentation", so that a Simple PR + Docs is still a Simple PR. Previously we experienced longer CI Build Times, just because we added docs to our Simple PR. (Now our PR shall be built exactly like a Simple PR)

The updated CI code is explained here: https://github.com/apache/nuttx/issues/13775

## Impact

With this PR, Build Jobs for Arm64 / x86_64 / Other will finish earlier:

- [__Before the PR:__](https://github.com/lupyuen5/label-nuttx/actions/runs/11335931870) Arm64 and x86_64 Build Jobs take up to 56 mins (`other`) to complete.

- [__After the PR:__](TODO) Arm64 and x86_64 Build Jobs will take at most ??? mins (`TODO`) to complete.

- PRs labeled "Arch: arm64" and/or "Board: arm64" will now build `arm64-01`. (Instead of `other`)

- PRs labeled "Arch: x86_64" and/or "Board: x86_64" will now build `x86_64-01`. (Instead of `other`)

- PRs with Docs will also build faster. (Assuming they are Simple PRs with One Arch and/or One Board)

The Updated CI Workflow shall be synced to `nuttx-apps` repo in the next PR.

## Testing

We verified that the Build Jobs for Arm64, x86_64 and Other are executed successfully with the Updated CI Workflow: TODO

[__Before the PR__](https://github.com/lupyuen5/label-nuttx/actions/runs/11335931870)
- other: 56 mins

[__After the PR__](TODO)
- other: ??? mins
- arm64-01: ??? mins
- x86_64-01: ??? mins

__Simple PR for Arm64 / x86_64:__ We tested by creating Simple PRs for Arm64 and x86_64
- ["Arch: arm64"](TODO) will build only `arm64-01`
- ["Board: arm64"](TODO) will build only `arm64-01`
- ["Arch: arm64, Board: arm64"](TODO) will build only `arm64-01`
- ["Arch: x86_64"](TODO) will build only `x86_64-01`
- ["Board: x86_64"](TODO) will build only `x86_64-01`
- ["Arch: x86_64, Board: x86_64"](TODO) will build only `x86_64-01`

__Simple PR with Documentation:__ We tested by creating Simple PRs that have docs
- ["Arch: arm, Area: Documentation"](TODO) will build only `arm-01` to `arm-14`
- ["Board: arm, Area: Documentation"](TODO) will build only `arm-01` to `arm-14`
- ["Arch: arm, Board: arm, Area: Documentation"](TODO) will build only `arm-01` to `arm-14`

__Regression Test:__ We tested by creating Simple PRs and Non-Simple PRs
- ["Arch: avr"](TODO) will build only `other`
- ["Arch: arm"](TODO) will build only `arm-01` to `arm-14`
- ["Board: arm"](TODO) will build only `arm-01` to `arm-14`
- ["Arch: arm, Board: arm"](TODO) will build only `arm-01` to `arm-14`
- ["Arch: risc-v"](TODO) will build only `risc-v-01` to `risc-v-06`
- ["Arch: sim"](TODO) will build only `sim-01` to `sim-02`
- ["Arch: xtensa"](TODO) will build only `xtensa-01` to `xtensa-02`
- ["Area: Documentation"](TODO) will build All Targets (because it's not a Simple PR)
- [Merging a PR](TODO) will also build All Targets